### PR TITLE
Stub COMMANDS and CLUSTER INFO

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -786,17 +787,19 @@ func (c *ClusterClient) lazyReloadState() {
 
 // Not thread-safe.
 func (c *ClusterClient) reloadState() (*clusterState, error) {
-	node, err := c.nodes.Random()
-	if err != nil {
-		return nil, err
-	}
+	return nil, errors.New("stubbing go-redis reloadState() for Clustered Redis")
 
-	slots, err := node.Client.ClusterSlots().Result()
-	if err != nil {
-		return nil, err
-	}
+	// node, err := c.nodes.Random()
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	return newClusterState(c.nodes, slots, node.Client.opt.Addr)
+	// slots, err := node.Client.ClusterSlots().Result()
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// return newClusterState(c.nodes, slots, node.Client.opt.Addr)
 }
 
 // reaper closes idle connections to the cluster.

--- a/ring.go
+++ b/ring.go
@@ -240,24 +240,26 @@ func (c *Ring) ForEachShard(fn func(client *Client) error) error {
 }
 
 func (c *Ring) cmdInfo(name string) *CommandInfo {
-	err := c.cmdsInfoOnce.Do(func() error {
-		var firstErr error
-		for _, shard := range c.shards {
-			cmdsInfo, err := shard.Client.Command().Result()
-			if err == nil {
-				c.cmdsInfo = cmdsInfo
-				return nil
-			}
-			if firstErr == nil {
-				firstErr = err
-			}
-		}
-		return firstErr
-	})
-	if err != nil {
-		return nil
-	}
-	return c.cmdsInfo[name]
+	return nil
+
+	// err := c.cmdsInfoOnce.Do(func() error {
+	// 	var firstErr error
+	// 	for _, shard := range c.shards {
+	// 		cmdsInfo, err := shard.Client.Command().Result()
+	// 		if err == nil {
+	// 			c.cmdsInfo = cmdsInfo
+	// 			return nil
+	// 		}
+	// 		if firstErr == nil {
+	// 			firstErr = err
+	// 		}
+	// 	}
+	// 	return firstErr
+	// })
+	// if err != nil {
+	// 	return nil
+	// }
+	// return c.cmdsInfo[name]
 }
 
 func (c *Ring) addClient(name string, cl *Client) {


### PR DESCRIPTION
Stubbing two calls that go-redis makes:

COMMANDS
CLUSTER INFO
These don't work with a non-clustered Redislabs instance and are sending 4k+ req/sec.

This is a temporary branch that should not be merged.